### PR TITLE
Add admin dashboard routing and user management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import CreateBlogPage from "./pages/CreateBlogPage";
 import BlogDetailPage from "./pages/BlogDetailPage";
 import CSRPage from "./pages/Csr";
 import InternshipPage from "./pages/Internship";
+import UserManagementPage from "./pages/UserManagementPage";
 
 export default function App() {
   const { isAdmin, user } = useAuth();
@@ -43,11 +44,11 @@ export default function App() {
         <Route path="/internship" element={<InternshipPage />} />
 
         {/* Admin auth routes */}
-        <Route path="/auth/admin/login" element={<AdminLoginPage />} />
-        <Route path="/auth/admin/register" element={<AdminRegisterPage />} />
+        <Route path="/login" element={<AdminLoginPage />} />
+        <Route path="/register" element={<AdminRegisterPage />} />
 
         <Route
-          path="/admin/dashboard"
+          path="/dashboard"
           element={
             <AdminLayout>
               <AdminDashboard />
@@ -59,6 +60,15 @@ export default function App() {
           element={
             <AdminLayout>
               <CreateBlogPage />
+            </AdminLayout>
+          }
+        />
+
+        <Route
+          path="/dashboard/users"
+          element={
+            <AdminLayout>
+              <UserManagementPage />
             </AdminLayout>
           }
         />

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -8,14 +8,14 @@ interface Props {
 }
 
 export default function AdminLayout({ children }: Props) {
-  const { isAdmin, isLoading, isAuthenticated } = useAuth();
+  const { isLoading, isAuthenticated } = useAuth();
 
   if (isLoading) {
     return <div>Loading...</div>;
   }
 
-  if (!isAuthenticated && isAdmin) {
-    return <Navigate to="/auth/admin/login" />;
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
   }
   return (
     <div className="flex h-screen bg-gray-100">

--- a/src/components/AdminRegisterPage.tsx
+++ b/src/components/AdminRegisterPage.tsx
@@ -54,7 +54,7 @@ function AdminRegisterPage() {
         };
         await login(userData, response.token);
         toast.success("Admin account created successfully!");
-        navigate("/admin/dashboard", { replace: true });
+        navigate("/dashboard", { replace: true });
       }
     } catch (error) {
       toast.error(

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -17,9 +17,9 @@ export function AdminSidebar() {
         <ul className="space-y-2">
           <li>
             <Link
-              to="/admin/dashboard"
+              to="/dashboard"
               className={`flex items-center p-2 rounded-md ${
-                isActive("/admin/dashboard")
+                isActive("/dashboard")
                   ? "bg-gray-700"
                   : "hover:bg-gray-700"
               }`}
@@ -39,9 +39,9 @@ export function AdminSidebar() {
           </li>
           <li>
             <Link
-              to="/admin/users"
+              to="/dashboard/users"
               className={`flex items-center p-2 rounded-md ${
-                isActive("/admin/users") ? "bg-gray-700" : "hover:bg-gray-700"
+                isActive("/dashboard/users") ? "bg-gray-700" : "hover:bg-gray-700"
               }`}
             >
               <span>User Management</span>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -101,7 +101,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
     setIsAdmin(false);
     localStorage.removeItem("token");
-    window.location.href = "/auth/admin/login";
+    window.location.href = "/login";
   };
 
   const value = {

--- a/src/hooks/useAdminAuth.ts
+++ b/src/hooks/useAdminAuth.ts
@@ -18,7 +18,7 @@ export const useRegisterAdmin = () => {
         await checkAdmin();
         queryClient.invalidateQueries({ queryKey: ["admin"] });
         toast.success("Admin account created successfully");
-        navigate("/admin/dashboard");
+        navigate("/dashboard");
       }
     },
     onError: (error: Error) => {
@@ -40,7 +40,7 @@ export const useLoginAdmin = () => {
         await checkAdmin();
         queryClient.invalidateQueries({ queryKey: ["admin"] });
         toast.success("Logged in successfully");
-        navigate("/admin/dashboard");
+        navigate("/dashboard");
       }
     },
     onError: (error: Error) => {

--- a/src/pages/UserManagementPage.tsx
+++ b/src/pages/UserManagementPage.tsx
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAllUsers } from "@/services/users";
+import Loader from "@/components/Loader";
+
+export default function UserManagementPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["users"],
+    queryFn: getAllUsers,
+  });
+
+  if (isLoading) return <Loader />;
+  if (error) return <div>Error: {(error as Error).message}</div>;
+
+  const users = data?.data.users || [];
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">User Management</h1>
+      <div className="overflow-x-auto bg-white rounded-lg shadow">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Name
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Email
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Role
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {users.map((user) => (
+              <tr key={user.id}>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  {user.firstName} {user.lastName}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">{user.email}</td>
+                <td className="px-6 py-4 whitespace-nowrap">{user.role}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
+                  <button className="text-blue-600 hover:text-blue-900">View</button>
+                  <button className="text-green-600 hover:text-green-900">Edit</button>
+                  <button className="text-red-600 hover:text-red-900">Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,0 +1,27 @@
+import axiosInstance from "./axiosInstance";
+import axios from "axios";
+
+export interface UsersResponse {
+  success: boolean;
+  data: {
+    users: {
+      id: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      role: string;
+    }[];
+  };
+}
+
+export const getAllUsers = async (): Promise<UsersResponse> => {
+  try {
+    const response = await axiosInstance.get("/api/users");
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      throw new Error(error.response?.data?.message || "Failed to fetch users");
+    }
+    throw new Error("Failed to fetch users");
+  }
+};


### PR DESCRIPTION
## Summary
- redirect admin users to `/dashboard` after login
- protect dashboard routes with authentication
- adjust login and register paths
- update sidebar links for new paths
- add user management page with user fetching

## Testing
- `npm run lint` *(fails: ESLint config issues)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686fbccca7ac8327a15686c0d5296f8e